### PR TITLE
fix mpu.colorbar for matplolib v3.4 and newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ helper functions for cartopy and matplotlib
 
 ### 0.3.0 (unreleased)
 
+#### Bug fixes
+
+ * Fixed compatibility of `mpu.colorbar` with `bbox_inches="tight"` for matplotlib 3.4 and
+   newer [#26](https://github.com/mathause/mplotutils/pull/26).
+
+#### Internal changes
+
  * Added ``nrow`` and ``ncol`` parameters to ``set_map_layout`` for use with a
    gridspec.
  * Replaced `ax.get_subplotspec().get_geometry()` with `ax.get_subplotspec().get_geometry()`

--- a/mplotutils/tests/test_colorbar_utils.py
+++ b/mplotutils/tests/test_colorbar_utils.py
@@ -104,7 +104,7 @@ def test_resize_colorbar_vert():
     res = [pos.x0, pos.y0, pos.width, pos.height]
     exp = [0.8, 0, 0.2 * 0.8, 1.0]
 
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     # -----------------------------------------------------------
 
@@ -115,7 +115,7 @@ def test_resize_colorbar_vert():
     res = [pos.x0, pos.y0, pos.width, pos.height]
     exp = [0.8, 0.1, 0.2 * 0.8, 0.8]
 
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     plt.close()
 
@@ -129,7 +129,7 @@ def test_resize_colorbar_vert():
     # don't test width if aspect is given, but also test aspect
     res = [pos.x0, pos.y0, pos.height]
     exp = [0.8, 0, 1.0]
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     assert cbar.ax.get_box_aspect() == 5
 
@@ -145,7 +145,7 @@ def test_resize_colorbar_vert():
     # don't test width if aspect is given, but also test aspect
     res = [pos.x0, pos.y0, pos.height]
     exp = [0.8, 0, 1.0]
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     assert cbar.ax.get_box_aspect() == 20
 
@@ -161,7 +161,7 @@ def test_resize_colorbar_vert():
     res = [pos.x0, pos.y0, pos.width, pos.height]
     exp = [0.8 + 0.8 * 0.05, 0, 0.8 * 0.1, 1.0]
 
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     plt.close()
 
@@ -176,7 +176,7 @@ def test_resize_colorbar_vert():
     res = [pos.x0, pos.y0, pos.width, pos.height]
     exp = [0.8, 0.05, 0.2 * 0.8, 0.9]
 
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     plt.close()
 
@@ -191,7 +191,7 @@ def test_resize_colorbar_vert():
     res = [pos.x0, pos.y0, pos.width, pos.height]
     exp = [0.8, 0.0, 0.2 * 0.8, 0.9]
 
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     plt.close()
 
@@ -206,7 +206,7 @@ def test_resize_colorbar_vert():
     res = [pos.x0, pos.y0, pos.width, pos.height]
     exp = [0.8, 0.1, 0.2 * 0.8, 0.9]
 
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     plt.close()
 
@@ -272,7 +272,7 @@ def test_resize_colorbar_horz():
     # don't test width if aspect is given, but also test aspect
     res = [pos.x0, pos.y0 + pos.height, pos.width]
     exp = [0.0, 0.2, 1.0]
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     assert cbar.ax.get_box_aspect() == 1.0 / 5
 
@@ -288,7 +288,7 @@ def test_resize_colorbar_horz():
     # don't test width if aspect is given, but also test aspect
     res = [pos.x0, pos.y0 + pos.height, pos.width]
     exp = [0.0, 0.2, 1.0]
-    np.testing.assert_allclose(res, exp)
+    np.testing.assert_allclose(res, exp, atol=1e-08)
 
     assert cbar.ax.get_box_aspect() == 1.0 / 20
 

--- a/mplotutils/tests/test_colorbar_utils.py
+++ b/mplotutils/tests/test_colorbar_utils.py
@@ -131,7 +131,7 @@ def test_resize_colorbar_vert():
     exp = [0.8, 0, 1.0]
     np.testing.assert_allclose(res, exp)
 
-    assert cbar.ax.get_aspect() == 5
+    assert cbar.ax.get_box_aspect() == 5
 
     plt.close()
 
@@ -147,7 +147,7 @@ def test_resize_colorbar_vert():
     exp = [0.8, 0, 1.0]
     np.testing.assert_allclose(res, exp)
 
-    assert cbar.ax.get_aspect() == 20
+    assert cbar.ax.get_box_aspect() == 20
 
     plt.close()
 
@@ -274,7 +274,7 @@ def test_resize_colorbar_horz():
     exp = [0.0, 0.2, 1.0]
     np.testing.assert_allclose(res, exp)
 
-    assert cbar.ax.get_aspect() == 1.0 / 5
+    assert cbar.ax.get_box_aspect() == 1.0 / 5
 
     plt.close()
 
@@ -290,7 +290,7 @@ def test_resize_colorbar_horz():
     exp = [0.0, 0.2, 1.0]
     np.testing.assert_allclose(res, exp)
 
-    assert cbar.ax.get_aspect() == 1.0 / 20
+    assert cbar.ax.get_box_aspect() == 1.0 / 20
 
     plt.close()
 


### PR DESCRIPTION
- Closes #6

The main difference is the usage of `set_box_aspect` instead of `set_aspect`. And also the correct computation of the position (this was simplified before and relied on mpl `bbox_inches="tight"` to cut them off).