### PR TITLE
make xarray a requirement

### DIFF
--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -5,7 +5,13 @@ channels:
 dependencies:
   - cartopy
   - matplotlib-base
+  - numpy
+  - seaborn
   - xarray
+# formatting
+  - black
+  - isort
+  - flake8
 # for testing
   - pytest
   - pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 cartopy >= 0.21
 matplotlib >= 3.6
 numpy >= 1.22
+xarray >= 2022.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,10 @@ zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.htm
 include_package_data = True
 python_requires = >=3.9
 install_requires =
-    cartopy >= 0.21
-    matplotlib >= 3.6
-    numpy >= 1.22
+    cartopy >=0.21
+    matplotlib >=3.6
+    numpy >=1.22
+    xarray >=2022.12
 
 [tool:pytest]
 filterwarnings =


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.md`

Explicitly require xarray. It was required before, now setup.cfg also reflects it. 