### PR TITLE
drop matplotlib 3.7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## v0.6.0 (unreleased)
 
-- The minimum versions of some dependencies were changed ([#88](https://github.com/mathause/mplotutils/pull/88)).
+### Breaking changes
+
+- The minimum versions of some dependencies were changed ([#117](https://github.com/mathause/mplotutils/pull/117)).
 
   | Package     | Old  | New     |
   | ----------- | ---- | ------- |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.6.0 (unreleased)
+
+- The minimum versions of some dependencies were changed ([#88](https://github.com/mathause/mplotutils/pull/88)).
+
+  | Package     | Old  | New     |
+  | ----------- | ---- | ------- |
+  | matplotlib* | 3.6  | 3.7     |
+
+
 
 ## v0.5.0 (27.03.2024)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 - Python (3.9 or later)
 - [cartopy](http://scitools.org.uk/cartopy/) (0.21 or later)
-- [matplotlib](http://matplotlib.org/) (3.6 or later)
+- [matplotlib](http://matplotlib.org/) (3.7 or later)
 - [numpy](http://www.numpy.org/) (1.22 or later)
 
 ## Optional dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 # https://help.github.com/en/github/visualizing-repository-data-with-graphs/listing-the-packages-that-a-repository-depends-on
 
 cartopy >= 0.21
-matplotlib >= 3.6
+matplotlib >= 3.7
 numpy >= 1.22
 xarray >= 2022.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ include_package_data = True
 python_requires = >=3.9
 install_requires =
     cartopy >=0.21
-    matplotlib >=3.6
+    matplotlib >=3.7
     numpy >=1.22
     xarray >=2022.12
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.md`
