### PR TITLE
case insensitive backend matching

### DIFF
--- a/mplotutils/tests/__init__.py
+++ b/mplotutils/tests/__init__.py
@@ -40,7 +40,7 @@ def restore_backend(backend):
 def _set_backend(backend):
 
     # WebAgg requires tornado, but this is only checked at runtime
-    if backend == "WebAgg":
+    if backend.lower() == "webagg":
         try:
             import tornado  # noqa: F401
         except ImportError:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

The backend name is now lower case (fixes failing tests in #121). Internal change only, so no changelog.