### PR TITLE
fix typos (using codespell)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,4 +152,4 @@ Mayor release, mostly introducing the new `colorbar` functionality.
 
 ## v0.1.0 (13.03.2018)
 
- * Functionality as developped for [pyvis](https://github.com/C2SM/pyvis/) (see below), packed into a module.
+ * Functionality as developed for [pyvis](https://github.com/C2SM/pyvis/) (see below), packed into a module.

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ See [CHANGELOG.md](CHANGELOG.md).
 
 ## History
 
-This package bases on functions developped for the [python visualisation workshop at C2SM](https://github.com/C2SM/pyvis/).
+This package bases on functions developed for the [python visualisation workshop at C2SM](https://github.com/C2SM/pyvis/).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,4 +31,4 @@ pip install git+https://github.com/mathause/mplotutils
 
 ### Install latest released version
 
-Go to the [newest release on github](https://github.com/mathause/mplotutils/releases/latest), copy the URL of the `*.tar.gz` source file at the botton and then use pip to install it (i.e. `pip install ...`).
+Go to the [newest release on github](https://github.com/mathause/mplotutils/releases/latest), copy the URL of the `*.tar.gz` source file at the bottom and then use pip to install it (i.e. `pip install ...`).

--- a/mplotutils/cartopy_utils.py
+++ b/mplotutils/cartopy_utils.py
@@ -24,9 +24,9 @@ def sample_data_map(nlons, nlats):
     Returns
     -------
     lon : ndarray
-        Array of the longitude coordiantes.
+        Array of the longitude coordinates.
     lat : ndarray
-        Array of the latitude coordiantes.
+        Array of the latitude coordinates.
     data : ndarray
         Sample data.
 
@@ -63,7 +63,7 @@ def sample_dataarray(nlon, nlat):
     Returns
     -------
     data : xr.DataArray
-        Sample data with coordiantes.
+        Sample data with coordinates.
 
     Notes
     -----

--- a/mplotutils/tests/test_hatch.py
+++ b/mplotutils/tests/test_hatch.py
@@ -121,7 +121,7 @@ def test_hatch_linewidth(function):
 
         assert mpl.rcParams["hatch.linewidth"] == 0.25
 
-    # chaning away from the default linewidth does not raise a warning
+    # changing away from the default linewidth does not raise a warning
     with subplots_context(1, 1, subplot_kw=subplot_kw) as (__, ax):
 
         function(da, "*", ax=ax)
@@ -132,7 +132,7 @@ def test_hatch_linewidth(function):
 
         assert mpl.rcParams["hatch.linewidth"] == 1
 
-    # chaning away from the default linewidth does not raise a warning
+    # changing away from the default linewidth does not raise a warning
     with subplots_context(1, 1, subplot_kw=subplot_kw) as (__, ax):
 
         function(da, "*", ax=ax, linewidth=2)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.md`

```bash
codespell --skip=".git,devel,_build" --ignore-words-list "" . --write-changes -i 3
```