### PR TITLE
adapt hatch for python ge 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@
   2. `mpu.hatch_map`: for cartopy GeoAxes
   3. `mpu.hatch_map_global`: as 2. but also adds a cyclic point to the array
 
-  all three functions expect a 2D boolean `xr.DataArray` and a hatch pattern. Values that are `True` are hatched.
+  all three functions expect a 2D boolean `xr.DataArray` and a hatch pattern. Values that are `True` are hatched
+  ([#123](https://github.com/mathause/mplotutils/pull/123) and [#143](https://github.com/mathause/mplotutils/pull/143)).
+
 
 - Enable passing `AxesGrid` (from `mpl_toolkits.axes_grid1`) to `set_map_layout` ([#116](https://github.com/mathause/mplotutils/pull/116)).
 - Raise more informative error when a wrong type is passed to `set_map_layout` ([#121](https://github.com/mathause/mplotutils/pull/121)).


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.md`


matplotlib 3.10 will support a per artist hatch linewidth - nice