### PR TITLE
ListedColormap: don't pass n colors

### DIFF
--- a/mplotutils/_colormaps.py
+++ b/mplotutils/_colormaps.py
@@ -55,7 +55,7 @@ def _color_palette(cmap, n_colors):
     colors_i = np.linspace(0, 1.0, n_colors)
     if isinstance(cmap, (list, tuple)):
         # we have a list of colors
-        cmap = ListedColormap(cmap, N=n_colors)
+        cmap = ListedColormap(cmap)
         pal = cmap(colors_i)
     elif isinstance(cmap, str):
         # we have some sort of named palette
@@ -71,7 +71,7 @@ def _color_palette(cmap, n_colors):
                 pal = color_palette(cmap, n_colors=n_colors)
             except (ValueError, ImportError):
                 # or maybe we just got a single color as a string
-                cmap = ListedColormap([cmap], N=n_colors)
+                cmap = ListedColormap([cmap] * n_colors)
                 pal = cmap(colors_i)
     else:
         # cmap better be a LinearSegmentedColormap (e.g. viridis)

--- a/mplotutils/tests/test_hatch.py
+++ b/mplotutils/tests/test_hatch.py
@@ -151,6 +151,7 @@ def test_hatch_linewidth_mpl_lt_310(function):
 
 
 @requires_mpl_ge_310
+@pytest.mark.filterwarnings("ignore:Passing 'N' to ListedColormap is deprecated")
 @pytest.mark.parametrize("function", HATCH_FUNCTIONS)
 def test_hatch_linewidth_mpl_ge_310(function):
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.md`

Should fix the failed upstream dev ci. Let's see if that also works for older versions of matplotlib.